### PR TITLE
Raise an error if person has lost authorization

### DIFF
--- a/spec/fixtures/lost_authorization/6133290.html
+++ b/spec/fixtures/lost_authorization/6133290.html
@@ -1,0 +1,129 @@
+
+<!DOCTYPE html>
+<html lang="no">
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <title>Personopplysninger - HPR</title>
+
+        <link href="/content/common/bundle?v=yXzgceRht3OU657i_FzkDrdFokpJCkhIIdXvKJw5CrQ1" rel="stylesheet"/>
+
+
+        <!--[if lt IE 9]>
+            <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
+
+
+    <link href="/content/hpr/bundle?v=4P1Lro0BbrRQxJX1DXT80f7kpXXANS9Ex4ZRXEi8uGQ1" rel="stylesheet"/>
+
+    <link href="/Content/Hpr/print.css" rel="stylesheet" media="print" />
+
+    </head>
+    <body>
+
+        <div id="main-container">
+
+            <header>
+
+
+    <div class="container">
+
+        <div class="top-navigation">
+            <a href="http://www.sak.no/" title="Til sak.no">
+                Til sak.no
+            </a>
+        </div>
+
+        <div class="header-left">
+            <h1>
+                <a href="/Hpr" title="Helsepersonellregisteret">
+                    Helsepersonellregisteret
+                </a>
+            </h1>
+        </div>
+
+        <div class="header-right">
+            <a href="http://www.sak.no" title="Statens Autorisasjonskontor for helsepersonell (SAK)">
+                <img src="/Content/Hpr/Images/logo-sak.png" alt="Statens Autorisasjonskontor for helsepersonell (SAK)"  />
+            </a>
+        </div>
+
+    </div>
+
+            </header>
+
+            <nav id="main-nav">
+
+    <div class="container">
+        <div class="menu-divider"></div>
+    </div>
+
+            </nav>
+
+
+            <div id="content">
+                <section>
+
+
+
+
+
+
+
+<div class="container">
+    <div class="content-pane">
+
+
+<div class="person-header">
+    <h2>OLE KRISTIAN  V&#197;GE</h2>
+
+    <p>
+        Fødselsdato: 15.06.1954<br />
+                    HPR-nummer: 6133290
+            </p>
+</div>
+
+    <div class="approval-box">
+        <h3>Ingen autorisasjon</h3>
+        <div class="clear-both"></div>
+    </div>
+
+
+
+<div class="lookup-footer">
+
+<a class="btn back-button" href="/Hpr" title="Tilbake til søkesiden">
+    <i class="icon-backward"></i> Tilbake til søkesiden
+</a>
+
+    <button class="btn pull-right" onclick="window.print()">
+        <i class="icon-print"></i> Skriv ut
+    </button>
+
+</div>
+
+
+    </div>
+</div>
+                </section>
+            </div>
+
+        </div>
+
+        <footer>
+
+
+        </footer>
+
+        <script src="/scripts/frameworks/bundle?v=31y8z400RIu0117MR5quFeubp1lFswOB093bkxAlH9k1"></script>
+
+
+    <script src="/scripts/frameworks/datepicker-nb?v=lvf1t3TEPhiJKIBMfGCYU6QyO4xkBY_ySCpV1X3nBJI1"></script>
+
+    <script src="/Scripts/HprScripts.js"></script>
+
+
+    </body>
+</html>

--- a/spec/lib/lost_authorization_spec.rb
+++ b/spec/lib/lost_authorization_spec.rb
@@ -1,0 +1,20 @@
+require_relative "../spec_helper"
+
+module Hpr
+  describe "Person has HPR entry, but no authorization" do
+
+    subject { Scraper.new(number) }
+
+    context "non-existing hpr number" do
+      let(:number) { "6133290" }
+
+      before do
+        stub_hpr_request(number, 'lost_authorization')
+      end
+
+      it "raises an exception" do
+        expect{ subject }.to raise_error(Scraper::MissingMedicalAuthorizationError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We previously raised an error if some HPR number could not be found in the hpr.sak.no database.

This adds support for handling cases where a person has had his/her authorization retracted, but still have a "profile" in the hpr registry.

Like this guy:

![image](https://cloud.githubusercontent.com/assets/97647/8227747/f0ac12e6-15a9-11e5-9c0e-8c997cbe63ae.png)


/cc @kiote