### PR TITLE
Improve parsing of HPR "profile"

### DIFF
--- a/lib/hpr/professional.rb
+++ b/lib/hpr/professional.rb
@@ -12,12 +12,17 @@ module Hpr
     APPROVED_INTERSHIP = "Godkjent turnus".freeze
     YES = "Ja".freeze
     SPECIALS = "Spesialitet".freeze
+    NO_AUTHORIZATION = "Ingen gjeldende autorisasjon".freeze
 
     include DateHelper
 
     # approval_box - as returned from Hpr::Scraper
     def initialize(approval_box)
       @approval_box = approval_box
+    end
+
+    def approved?
+      approval_row && !approval.include?(NO_AUTHORIZATION)
     end
 
     def approval

--- a/lib/hpr/professional.rb
+++ b/lib/hpr/professional.rb
@@ -37,7 +37,9 @@ module Hpr
     end
 
     def requisition_privilege
-      @requisition_privilege ||= requisition_privilege_row.at_css(".cell2").text.strip
+      if requisition_privilege_row
+        @requisition_privilege ||= requisition_privilege_row.at_css(".cell2").text.strip
+      end
     end
 
     def requisition_privilege_period

--- a/spec/fixtures/dentists/9877770.html
+++ b/spec/fixtures/dentists/9877770.html
@@ -1,0 +1,180 @@
+
+<!DOCTYPE html>
+<html lang="no">
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <title>Personopplysninger - HPR</title>
+
+        <link href="/content/common/bundle?v=yXzgceRht3OU657i_FzkDrdFokpJCkhIIdXvKJw5CrQ1" rel="stylesheet"/>
+
+
+        <!--[if lt IE 9]>
+            <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
+
+
+    <link href="/content/hpr/bundle?v=4P1Lro0BbrRQxJX1DXT80f7kpXXANS9Ex4ZRXEi8uGQ1" rel="stylesheet"/>
+
+    <link href="/Content/Hpr/print.css" rel="stylesheet" media="print" />
+
+    </head>
+    <body>
+
+        <div id="main-container">
+
+            <header>
+
+
+    <div class="container">
+
+        <div class="top-navigation">
+            <a href="http://www.sak.no/" title="Til sak.no">
+                Til sak.no
+            </a>
+        </div>
+
+        <div class="header-left">
+            <h1>
+                <a href="/Hpr" title="Helsepersonellregisteret">
+                    Helsepersonellregisteret
+                </a>
+            </h1>
+        </div>
+
+        <div class="header-right">
+            <a href="http://www.sak.no" title="Statens Autorisasjonskontor for helsepersonell (SAK)">
+                <img src="/Content/Hpr/Images/logo-sak.png" alt="Statens Autorisasjonskontor for helsepersonell (SAK)"  />
+            </a>
+        </div>
+
+    </div>
+
+            </header>
+
+            <nav id="main-nav">
+
+    <div class="container">
+        <div class="menu-divider"></div>
+    </div>
+
+            </nav>
+
+
+            <div id="content">
+                <section>
+
+
+
+
+
+
+
+<div class="container">
+    <div class="content-pane">
+
+
+<div class="person-header">
+    <h2>Mats Ola  Larsson</h2>
+
+    <p>
+        Fødselsdato: 02.10.1947<br />
+                    HPR-nummer: 9877770
+
+                <br />
+                <span class="text-error">Mangler norsk identifikator i register (fødselsnummer).</span>
+                <br />
+                <a href="https://www.altinn.no/Pages/ServiceEngine/Start/StartService.aspx?ServiceEditionCode=141001&ServiceCode=3893">Registrer fødselsnummer i Altinn.</a>
+
+    </p>
+</div>
+
+
+
+    <div class="approval-box">
+
+        <h3>Tannlege</h3>
+
+        <div class="clear-both"></div>
+
+        <div class="data-entry first" style="position: relative;">
+            <div class="cell1">Godkjenning</div>
+
+                <div class="cell2">
+                    Autorisasjon
+                </div>
+                <div class="cell3">Gyldig fra:</div>
+                <div class="cell4"> 13.03.2008</div>
+                <div class="cell5">Gyldig til:</div>
+                <div class="cell6"> 02.10.2022</div>
+
+            <div class="clear-both"></div>
+
+            <div class="ui-autocomplete" id="vilkaarPopup">
+                Ta kontakt med arbeidsgiver eller Helsetilsynet ved behov for informasjon om vilkårene
+            </div>
+        </div>
+
+
+                <div class="data-entry">
+                    <div class="cell1">Spesialitet</div>
+                    <div class="cell2">
+                        Kjeveortopedi
+                    </div>
+                    <div class="cell3">Gyldig fra:</div>
+                    <div class="cell4"> 23.04.2008</div>
+                    <div class="cell5">Gyldig til:</div>
+                    <div class="cell6"> 02.10.2022</div>
+                    <div class="clear-both"></div>
+                </div>
+                <div class="data-entry">
+                    <div class="cell1">Tilleggskompetanse</div>
+                    <div class="cell2">
+                        Godkjent implantatprotetisk behandler
+                    </div>
+                    <div class="cell3">Gyldig fra:</div>
+                    <div class="cell4"> 18.06.2008</div>
+                    <div class="cell5">Gyldig til:</div>
+                    <div class="cell6"> 02.10.2022</div>
+                    <div class="clear-both"></div>
+                </div>
+
+    </div>
+
+<div class="lookup-footer">
+
+<a class="btn back-button" href="/Hpr" title="Tilbake til søkesiden">
+    <i class="icon-backward"></i> Tilbake til søkesiden
+</a>
+
+    <button class="btn pull-right" onclick="window.print()">
+        <i class="icon-print"></i> Skriv ut
+    </button>
+
+</div>
+
+
+    </div>
+</div>
+                </section>
+            </div>
+
+        </div>
+
+        <footer>
+
+
+        </footer>
+
+        <script src="/scripts/frameworks/bundle?v=31y8z400RIu0117MR5quFeubp1lFswOB093bkxAlH9k1"></script>
+
+
+    <script src="/scripts/frameworks/datepicker-nb?v=lvf1t3TEPhiJKIBMfGCYU6QyO4xkBY_ySCpV1X3nBJI1"></script>
+
+    <script src="/Scripts/HprScripts.js"></script>
+
+
+    </body>
+</html>

--- a/spec/fixtures/lost_authorization/6128459.html
+++ b/spec/fixtures/lost_authorization/6128459.html
@@ -1,0 +1,171 @@
+
+<!DOCTYPE html>
+<html lang="no">
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <title>Personopplysninger - HPR</title>
+
+        <link href="/content/common/bundle?v=yXzgceRht3OU657i_FzkDrdFokpJCkhIIdXvKJw5CrQ1" rel="stylesheet"/>
+
+
+        <!--[if lt IE 9]>
+            <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
+
+
+    <link href="/content/hpr/bundle?v=4P1Lro0BbrRQxJX1DXT80f7kpXXANS9Ex4ZRXEi8uGQ1" rel="stylesheet"/>
+
+    <link href="/Content/Hpr/print.css" rel="stylesheet" media="print" />
+
+    </head>
+    <body>
+
+        <div id="main-container">
+
+            <header>
+
+
+    <div class="container">
+
+        <div class="top-navigation">
+            <a href="http://www.sak.no/" title="Til sak.no">
+                Til sak.no
+            </a>
+        </div>
+
+        <div class="header-left">
+            <h1>
+                <a href="/Hpr" title="Helsepersonellregisteret">
+                    Helsepersonellregisteret
+                </a>
+            </h1>
+        </div>
+
+        <div class="header-right">
+            <a href="http://www.sak.no" title="Statens Autorisasjonskontor for helsepersonell (SAK)">
+                <img src="/Content/Hpr/Images/logo-sak.png" alt="Statens Autorisasjonskontor for helsepersonell (SAK)"  />
+            </a>
+        </div>
+
+    </div>
+
+            </header>
+
+            <nav id="main-nav">
+
+    <div class="container">
+        <div class="menu-divider"></div>
+    </div>
+
+            </nav>
+
+
+            <div id="content">
+                <section>
+
+
+
+
+
+
+
+<div class="container">
+    <div class="content-pane">
+
+
+<div class="person-header">
+    <h2>JAN ANDRE  ANDERSEN</h2>
+
+    <p>
+        Fødselsdato: 02.06.1959<br />
+                    HPR-nummer: 6128459
+            </p>
+</div>
+
+
+
+    <div class="approval-box">
+
+        <h3>Sykepleier</h3>
+
+        <div class="clear-both"></div>
+
+        <div class="data-entry first" style="position: relative;">
+            <div class="cell1">Godkjenning</div>
+
+                <div class="cell2">
+                    Ingen gjeldende autorisasjon.
+                </div>
+
+            <div class="clear-both"></div>
+
+            <div class="ui-autocomplete" id="vilkaarPopup">
+                Ta kontakt med arbeidsgiver eller Helsetilsynet ved behov for informasjon om vilkårene
+            </div>
+        </div>
+
+
+
+    </div>
+    <div class="approval-box">
+
+        <h3>Tannlege</h3>
+
+        <div class="clear-both"></div>
+
+        <div class="data-entry first" style="position: relative;">
+            <div class="cell1">Godkjenning</div>
+
+                <div class="cell2">
+                    Ingen gjeldende autorisasjon.
+                </div>
+
+            <div class="clear-both"></div>
+
+            <div class="ui-autocomplete" id="vilkaarPopup">
+                Ta kontakt med arbeidsgiver eller Helsetilsynet ved behov for informasjon om vilkårene
+            </div>
+        </div>
+
+
+
+    </div>
+
+<div class="lookup-footer">
+
+<a class="btn back-button" href="/Hpr" title="Tilbake til søkesiden">
+    <i class="icon-backward"></i> Tilbake til søkesiden
+</a>
+
+    <button class="btn pull-right" onclick="window.print()">
+        <i class="icon-print"></i> Skriv ut
+    </button>
+
+</div>
+
+
+    </div>
+</div>
+                </section>
+            </div>
+
+        </div>
+
+        <footer>
+
+
+        </footer>
+
+        <script src="/scripts/frameworks/bundle?v=31y8z400RIu0117MR5quFeubp1lFswOB093bkxAlH9k1"></script>
+
+
+    <script src="/scripts/frameworks/datepicker-nb?v=lvf1t3TEPhiJKIBMfGCYU6QyO4xkBY_ySCpV1X3nBJI1"></script>
+
+    <script src="/Scripts/HprScripts.js"></script>
+
+
+    </body>
+</html>

--- a/spec/lib/dentist_spec.rb
+++ b/spec/lib/dentist_spec.rb
@@ -2,65 +2,83 @@ require_relative "../spec_helper"
 
 module Hpr
   describe "Dentist" do
-    let(:number) { "3049523" }
-    let(:period) { Date.new(1991, 7, 4)..Date.new(2041, 11, 5) }
-
-    subject { Scraper.new(number) }
+    subject { Scraper.new(hpr_number) }
     let(:dentist) { subject.dentist }
 
     before do
-      stub_hpr_request(number, 'dentists')
+      stub_hpr_request(hpr_number, 'dentists')
     end
 
-    it "scrapes the birth name" do
-      expect(subject.name).to eq("ANNE GULBRANDSEN KHAZAIE")
-    end
+    context 'dentist with all fields filled in' do
+      let(:hpr_number) { "3049523" }
+      let(:period) { Date.new(1991, 7, 4)..Date.new(2041, 11, 5) }
 
-    it "scrapes the birth date" do
-      expect(subject.birth_date).to eq(Date.new(1966, 11, 5))
-    end
-
-    it "scrapes the profession" do
-      expect(subject.dentist?).to be_truthy
-      expect(subject.physician?).to be_falsey
-    end
-
-    describe "approval" do
-      it "scrapes the approval mechanism" do
-        expect(dentist.approval).to eq("Autorisasjon")
+      it "scrapes the birth name" do
+        expect(subject.name).to eq("ANNE GULBRANDSEN KHAZAIE")
       end
 
-      it "scrapes the approval period" do
-        expect(dentist.approval_period).to eq(period)
+      it "scrapes the birth date" do
+        expect(subject.birth_date).to eq(Date.new(1966, 11, 5))
+      end
+
+      it "scrapes the profession" do
+        expect(subject.dentist?).to be_truthy
+        expect(subject.physician?).to be_falsey
+      end
+
+      describe 'approved?' do
+        it 'returns true' do
+          expect(dentist.approved?).to eq true
+        end
+      end
+
+      describe "approval" do
+        it "scrapes the approval mechanism" do
+          expect(dentist.approval).to eq("Autorisasjon")
+        end
+
+        it "scrapes the approval period" do
+          expect(dentist.approval_period).to eq(period)
+        end
+      end
+
+      describe "requisition privilege" do
+        it "scrapes the requisition privilege procedure" do
+          expect(dentist.requisition_privilege).to eq("Full rekvisisjonsrett")
+        end
+
+        it "scrapes the requisition privilege period" do
+          expect(dentist.requisition_privilege_period).to eq(period)
+        end
+      end
+
+      it "scrapes any specials" do
+        expect(dentist.specials).to be_empty
+      end
+
+      it "scrapes any additional expertise" do
+        expertise = dentist.additional_expertise
+        expect(expertise.count).to equal(1)
+
+        exp = expertise.first
+        expect(exp.name).to eq("Godkjent implantatprotetisk behandler")
+        expect(exp.period.first).to eq(Date.new(2011, 1, 5))
+        expect(exp.period.last).to eq(Date.new(2041, 11, 5))
+      end
+
+      it "knows whether the internship has been approved" do
+        expect(dentist.approved_internship?).to be_falsey
       end
     end
 
-    describe "requisition privilege" do
-      it "scrapes the requisition privilege procedure" do
-        expect(dentist.requisition_privilege).to eq("Full rekvisisjonsrett")
+    context 'dentist without requisition privileges' do
+      let(:hpr_number) { "9877770" }
+
+      describe "requisition privilege" do
+        it "returns nil" do
+          expect(dentist.requisition_privilege).to eq nil
+        end
       end
-
-      it "scrapes the requisition privilege period" do
-        expect(dentist.requisition_privilege_period).to eq(period)
-      end
-    end
-
-    it "scrapes any specials" do
-      expect(dentist.specials).to be_empty
-    end
-
-    it "scrapes any additional expertise" do
-      expertise = dentist.additional_expertise
-      expect(expertise.count).to equal(1)
-
-      exp = expertise.first
-      expect(exp.name).to eq("Godkjent implantatprotetisk behandler")
-      expect(exp.period.first).to eq(Date.new(2011, 1, 5))
-      expect(exp.period.last).to eq(Date.new(2041, 11, 5))
-    end
-
-    it "knows whether the internship has been approved" do
-      expect(dentist.approved_internship?).to be_falsey
     end
   end
 end

--- a/spec/lib/lost_authorization_spec.rb
+++ b/spec/lib/lost_authorization_spec.rb
@@ -3,9 +3,9 @@ require_relative "../spec_helper"
 module Hpr
   describe "Person has HPR entry, but no authorization" do
 
-    subject { Scraper.new(number) }
+    let(:scraper) { Scraper.new(number) }
 
-    context "non-existing hpr number" do
+    context "person used to be authorized in single category" do
       let(:number) { "6133290" }
 
       before do
@@ -13,7 +13,22 @@ module Hpr
       end
 
       it "raises an exception" do
-        expect{ subject }.to raise_error(Scraper::MissingMedicalAuthorizationError)
+        expect{ scraper }.to raise_error(Scraper::MissingMedicalAuthorizationError)
+      end
+    end
+
+    context 'person used to be authorized in multiple categories' do
+      let(:number) { "6128459" }
+      let(:professional) { Professional.new(scraper.dentist_approval_box) }
+
+      before do
+        stub_hpr_request(number, 'lost_authorization')
+      end
+
+      describe 'approved?' do
+        it 'returns false' do
+          expect(professional.approved?).to eq false
+        end
       end
     end
   end


### PR DESCRIPTION
The commits are best viewed separately. Both will reduce the number of errors we see when parsing HPR "profile" pages.

/cc @kiote