### PR TITLE
Move definition of errors from Hpr::Scraper to Hpr

### DIFF
--- a/lib/hpr.rb
+++ b/lib/hpr.rb
@@ -3,4 +3,7 @@
 require "hpr/version"
 require "hpr/scraper"
 
-module Hpr end
+module Hpr
+  class MissingMedicalAuthorizationError < ArgumentError; end
+  class InvalidHprNumberError < MissingMedicalAuthorizationError; end
+end

--- a/lib/hpr/scraper.rb
+++ b/lib/hpr/scraper.rb
@@ -6,9 +6,6 @@ require "hpr/professional"
 
 module Hpr
   class Scraper
-    class MissingMedicalAuthorizationError < ArgumentError; end
-    class InvalidHprNumberError < MissingMedicalAuthorizationError; end
-
     BASE_URL = "https://hpr.sak.no/Hpr/Hpr/Lookup".freeze
     PHYSICIAN = "Lege".freeze
     DENTIST = "Tannlege".freeze
@@ -24,9 +21,9 @@ module Hpr
       @page = Nokogiri::HTML(RestClient.post(BASE_URL, {"Number" => hpr_number}))
 
       if hpr_number_not_found?
-        raise InvalidHprNumberError, "HPR number: #{hpr_number}"
+        raise Hpr::InvalidHprNumberError, "HPR number: #{hpr_number}"
       elsif person_has_lost_authorization?
-        raise MissingMedicalAuthorizationError, "HPR number: #{hpr_number}"
+        raise Hpr::MissingMedicalAuthorizationError, "HPR number: #{hpr_number}"
       end
     end
 

--- a/spec/lib/lost_authorization_spec.rb
+++ b/spec/lib/lost_authorization_spec.rb
@@ -13,7 +13,7 @@ module Hpr
       end
 
       it "raises an exception" do
-        expect{ scraper }.to raise_error(Scraper::MissingMedicalAuthorizationError)
+        expect{ scraper }.to raise_error(MissingMedicalAuthorizationError)
       end
     end
 

--- a/spec/lib/not_found_spec.rb
+++ b/spec/lib/not_found_spec.rb
@@ -13,7 +13,7 @@ module Hpr
       end
 
       it "raises an exception" do
-        expect{ subject }.to raise_error(Scraper::InvalidHprNumberError)
+        expect{ subject }.to raise_error(InvalidHprNumberError)
       end
     end
 
@@ -25,7 +25,7 @@ module Hpr
       end
 
       it "raises an exception" do
-        expect{ subject }.to raise_error(Scraper::InvalidHprNumberError)
+        expect{ subject }.to raise_error(InvalidHprNumberError)
       end
     end
   end


### PR DESCRIPTION
When using this library, it makes a bit more sense for me to relate to errors directly under Hpr, ie. Hpr::InvalidHprNumber, not Hpr::Scraper::InvalidHprNumber.

As a bonus it's shorter to write, too. :-)

/cc @kiote