### PR TITLE
Avoid throwing error when no requisition privileges

### DIFF
--- a/lib/hpr/professional.rb
+++ b/lib/hpr/professional.rb
@@ -43,10 +43,9 @@ module Hpr
     end
 
     def requisition_privilege_period
-      unless instance_variable_defined?(:@requisition_privilege_period)
-        @requisition_privilege_period = period(requisition_privilege_row)
+      if requisition_privilege_row
+        @requisition_privilege_period ||= period(requisition_privilege_row)
       end
-      @requisition_privilege_period
     end
 
     def additional_expertise

--- a/spec/fixtures/no_requisition_rights/9364684.html
+++ b/spec/fixtures/no_requisition_rights/9364684.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="no">
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <title>Personopplysninger - HPR</title>
+
+        <link href="/content/common/bundle?v=yXzgceRht3OU657i_FzkDrdFokpJCkhIIdXvKJw5CrQ1" rel="stylesheet"/>
+
+
+        <!--[if lt IE 9]>
+            <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
+
+
+    <link href="/content/hpr/bundle?v=4P1Lro0BbrRQxJX1DXT80f7kpXXANS9Ex4ZRXEi8uGQ1" rel="stylesheet"/>
+
+    <link href="/Content/Hpr/print.css" rel="stylesheet" media="print" />
+
+    </head>
+    <body>
+
+        <div id="main-container">
+
+            <header>
+
+
+    <div class="container">
+
+        <div class="top-navigation">
+            <a href="http://www.sak.no/" title="Til sak.no">
+                Til sak.no
+            </a>
+        </div>
+
+        <div class="header-left">
+            <h1>
+                <a href="/Hpr" title="Helsepersonellregisteret">
+                    Helsepersonellregisteret
+                </a>
+            </h1>
+        </div>
+
+        <div class="header-right">
+            <a href="http://www.sak.no" title="Statens Autorisasjonskontor for helsepersonell (SAK)">
+                <img src="/Content/Hpr/Images/logo-sak.png" alt="Statens Autorisasjonskontor for helsepersonell (SAK)"  />
+            </a>
+        </div>
+
+    </div>
+
+            </header>
+
+            <nav id="main-nav">
+
+    <div class="container">
+        <div class="menu-divider"></div>
+    </div>
+
+            </nav>
+
+
+            <div id="content">
+                <section>
+
+
+
+
+
+
+
+<div class="container">
+    <div class="content-pane">
+
+
+<div class="person-header">
+    <h2>ANDREAS GEORGE  GONDOS</h2>
+
+    <p>
+        Fødselsdato: 08.11.1962<br />
+                    HPR-nummer: 9364684
+            </p>
+</div>
+
+
+
+    <div class="approval-box">
+
+        <h3>Lege</h3>
+
+        <div class="clear-both"></div>
+
+        <div class="data-entry first" style="position: relative;">
+            <div class="cell1">Godkjenning</div>
+
+                <div class="cell2">
+                    Autorisasjon
+                </div>
+                <div class="cell3">Gyldig fra:</div>
+                <div class="cell4"> 18.05.2005</div>
+                <div class="cell5">Gyldig til:</div>
+                <div class="cell6"> 08.11.2037</div>
+
+            <div class="clear-both"></div>
+
+            <div class="ui-autocomplete" id="vilkaarPopup">
+                Ta kontakt med arbeidsgiver eller Helsetilsynet ved behov for informasjon om vilkårene
+            </div>
+        </div>
+
+
+                <div class="data-entry">
+                    <div class="cell1">Tilleggskompetanse</div>
+                    <div class="cell2">
+                        Allmennlege med trygderefusjon
+                    </div>
+                    <div class="cell3">Gyldig fra:</div>
+                    <div class="cell4"> 27.10.2009</div>
+                    <div class="cell5">Gyldig til:</div>
+                    <div class="cell6"> 08.11.2037</div>
+                    <div class="clear-both"></div>
+                </div>
+
+            <div class="data-entry" style="position: relative;" id="godkjentTurnusDiv">
+                <div class="cell1">Godkjent turnus <span class="badge">i</span></div>
+                <div class="cell2">Ja</div>
+                <div class="cell3">18.05.2005</div>
+                <div class="clear-both"></div>
+
+                    <div class="ui-autocomplete" id="godkjentTurnusInfoPopup">
+                        «Godkjent turnus» viser om legen har gjennomført og godkjent turnustjenesten i Norge, eller har fått godkjent hele eller deler av veiledet praksis fra andre EØS-land.<br />
+                        For flere opplysninger og informasjon om tilsettelse av leger som ikke har «godkjent turnus» oppført i HPR, se våre nettsider:<br />
+                        <a id="godkjentTurnusInfoUrl" href="http://www.sak.no/om-sak/nyheter/Sider/informasjon-om-gjennomfort-turnustjeneste-i-helsepersonellregisteret-hpr.aspx">http://www.sak.no/om-sak/nyheter/Sider/informasjon-om-gjennomfort-turnustjeneste-i-helsepersonellregisteret-hpr.aspx</a>.
+                    </div>
+            </div>
+    </div>
+
+<div class="lookup-footer">
+
+<a class="btn back-button" href="/Hpr" title="Tilbake til søkesiden">
+    <i class="icon-backward"></i> Tilbake til søkesiden
+</a>
+
+    <button class="btn pull-right" onclick="window.print()">
+        <i class="icon-print"></i> Skriv ut
+    </button>
+
+</div>
+
+
+    </div>
+</div>
+                </section>
+            </div>
+
+        </div>
+
+        <footer>
+
+
+        </footer>
+
+        <script src="/scripts/frameworks/bundle?v=31y8z400RIu0117MR5quFeubp1lFswOB093bkxAlH9k1"></script>
+
+
+    <script src="/scripts/frameworks/datepicker-nb?v=lvf1t3TEPhiJKIBMfGCYU6QyO4xkBY_ySCpV1X3nBJI1"></script>
+
+    <script src="/Scripts/HprScripts.js"></script>
+
+
+    </body>
+</html>

--- a/spec/lib/no_requisition_privileges_spec.rb
+++ b/spec/lib/no_requisition_privileges_spec.rb
@@ -1,0 +1,28 @@
+require_relative "../spec_helper"
+
+module Hpr
+  context 'Missing requisition privileges' do
+    let(:scraper) { Scraper.new(number) }
+
+    context 'requisition privileges' do
+      let(:number) { "9364684" }
+      let(:professional) { Professional.new(scraper.physician_approval_box) }
+
+      before do
+        stub_hpr_request(number, 'no_requisition_rights')
+      end
+
+      context 'privilege name' do
+        it 'returns nil' do
+          expect(professional.requisition_privilege).to eq nil
+        end
+      end
+
+      context 'privilege period' do
+        it 'returns nil' do
+          expect(professional.requisition_privilege_period).to eq nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A bug in Hpr::Professional#requisition_privilege_period
caused an error when the object in HPR had no
requisition privileges.

This fix makes the method return nil in these cases.

Related to legelisten/legelisten#496

/cc @kiote